### PR TITLE
text and link revision

### DIFF
--- a/custom_theme_files/base.html
+++ b/custom_theme_files/base.html
@@ -201,10 +201,10 @@
               <br />
               Do you have an issue with this page of the DevCenter?
               <br />
-              Feel free to create an issue on the <a href="{{ repo_url }}">DevCenter's GitHub page</a>,
-              or to <a href="https://www.bitrise.io/contact">contact us</a>!
+              Feel free to <a href="{{ repo_url }}/issues/new?title=PAGE:{{ page.title }}" target="_blank">create an issue on the DevCenter's GitHub page</a>,
+              or to <a href="https://www.bitrise.io/contact" target="_blank">contact us</a>!
               <br />
-              You can also edit the pages on <a href="{{ page.edit_url }}">GitHub</a> directly, you don't have to git clone the repository.
+              You can also edit this page on <a href="{{ page.edit_url }}">GitHub</a> directly, you don't have to git clone the repository.
               <br />
               Just <a href="{{ page.edit_url }}">select the file on GitHub</a> and click the <b>pencil/edit icon</b>,
               which will open the GitHub editor for the file.


### PR DESCRIPTION
the "create a github issue" link now links to a "create new issue" page, with the page title pre-filled

both "contact us" links are now with target blank, to make it easy to link to the related page

and a minor text fix for "edit this page on GitHub"