### PR TITLE
Adding a link to Swift compiling advices repository

### DIFF
--- a/docs/tips-and-tricks/optimize-your-build-times.md
+++ b/docs/tips-and-tricks/optimize-your-build-times.md
@@ -34,6 +34,8 @@ but subsequent Xcode steps can use the build cache of the previous Xcode step(s)
 
 ## Other
 
+Stay updated with Swift compiling tips: https://github.com/fastred/Optimizing-Swift-Build-Times
+
 __Feel free to suggest other ways of optimization!__
 
 - [Guarding Against Long Compiles](http://khanlou.com/2016/12/guarding-against-long-compiles/)

--- a/docs/tips-and-tricks/optimize-your-build-times.md
+++ b/docs/tips-and-tricks/optimize-your-build-times.md
@@ -34,8 +34,7 @@ but subsequent Xcode steps can use the build cache of the previous Xcode step(s)
 
 ## Other
 
-Stay updated with Swift compiling tips: https://github.com/fastred/Optimizing-Swift-Build-Times
-
 __Feel free to suggest other ways of optimization!__
 
 - [Guarding Against Long Compiles](http://khanlou.com/2016/12/guarding-against-long-compiles/)
+- [Stay updated with Swift compiling tips](https://github.com/fastred/Optimizing-Swift-Build-Times)


### PR DESCRIPTION
It was added a link to a github repository that contains advices about how decrease Swift compiling time. It worked fine in my project, decreased more than a minute of build time in bitrise.