### PR TITLE
Fix link to envman

### DIFF
--- a/_articles/tools/bitrise-tools.md
+++ b/_articles/tools/bitrise-tools.md
@@ -18,7 +18,7 @@ For historical reasons the core Bitrise CLI tools live in [github.com/bitrise-io
 * [stepman](https://github.com/bitrise-io/stepman) -
   used for managing the Step Library, including
   downloading and sharing steps.
-* [envman](https://github.com/bitrise-io/bitrise) -
+* [envman](https://github.com/bitrise-io/envman) -
   environment variable manager, can be used independently
   and Bitrise CLI uses it to isolate and manage environment variables during the build.
 


### PR DESCRIPTION
Link to bitrise-io/envman, not bitrise-io/bitrise.