### PR TITLE
Ignore .bundle and vendor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,16 @@
-node_modules
-gg.conf.json
-_site
-.bitrise.secrets.yml
+# General
 .DS_Store
+gg.conf.json
+
+# Ignore node_modules
+node_modules
+
+# Environment normalization
 .bundle
 vendor
+
+# Build output
+_site
+
+# Secrets
+.bitrise.secrets.yml

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ gg.conf.json
 _site
 .bitrise.secrets.yml
 .DS_Store
+.bundle
+vendor


### PR DESCRIPTION
`.bundle` and `vendor` are obstacle when we preview locally.
So these should be ignored.
And I improved `.gitignore` because old one was little hard to read.