### PR TITLE
Fix for broken link

### DIFF
--- a/_articles/tutorials/docker/use-your-own-docker-image.md
+++ b/_articles/tutorials/docker/use-your-own-docker-image.md
@@ -29,7 +29,7 @@ You have to:
 We provide three examples on how to run Docker commands using our `Script` Step:
 
 * [Running docker hello-world](/tutorials/docker/use-your-own-docker-image/#running-docker-hello-world)
-* [Building and running a Dockerfile](/tutorials/docker/use-your-own-docker-image/#build-and-run-a-dockerfile)
+* [Building and running a Dockerfile](/tutorials/docker/use-your-own-docker-image/#building-and-running-a-dockerfile)
 * [Using docker-compose](/tutorials/docker/use-your-own-docker-image/#using-docker-compose)
 
 ### Running docker hello-world


### PR DESCRIPTION
The link for the second example "Building and running a Dockerfile" was going to the top of the page instead of to the example.