### PR TITLE
Remove Mojave specific section, include the PEM option by default

### DIFF
--- a/_articles/faq/how-to-generate-ssh-keypair.md
+++ b/_articles/faq/how-to-generate-ssh-keypair.md
@@ -8,11 +8,7 @@ menu:
 If you want to do manual SSH key configuration on [bitrise.io](https://www.bitrise.io)
 you can generate an appropriate SSH keypair with a simple Command Line / Terminal command:
 
-    ssh-keygen -t rsa -b 4096 -P '' -f ./bitrise-ssh
-
-{% include message_box.html type="info" title="Mojave issues" content="If you are on the Mojave OS, and having difficulties with the above command, use the following: 
-
-`ssh-keygen -t rsa -b 4096 -P '' -f ./bitrise-ssh -m PEM` "%} 
+    ssh-keygen -t rsa -b 4096 -P '' -f ./bitrise-ssh -m PEM
 
 This will generate two files in the current directory (the directory where
 you run the command):


### PR DESCRIPTION
`-m PEM` is supported everywhere, it will not cause any issues, it's just that on most systems `-m PEM` is the default so you don't have to add it (but you still can of course), while on Mojave it's no longer the default so you have to specify it.