### PR TITLE
Fixes the getting-started links for two sections on the iOS page

### DIFF
--- a/_articles/en/getting-started/getting-started-with-ios-apps.md
+++ b/_articles/en/getting-started/getting-started-with-ios-apps.md
@@ -11,8 +11,8 @@ Developing for iOS is not always easy - our aim is to make it as simple as possi
 
 * [Adding an iOS app](/getting-started/getting-started-with-ios-apps/#adding-an-ios-app)
 * [Running Xcode tests](/getting-started/getting-started-with-ios-apps/#running-xcode-tests)
-* [Code signing and exporting an .ipa](/getting-started-with-ios-apps/#code-signing-and-exporting-an-ipa)
-* [Deploying to TestFlight and the App Store](/getting-started-with-ios-apps/#deploying-to-testflight-and-the-app-store)
+* [Code signing and exporting an .ipa](/getting-started/getting-started-with-ios-apps/#code-signing-and-exporting-an-ipa)
+* [Deploying to TestFlight and the App Store](/getting-started/getting-started-with-ios-apps/#deploying-to-testflight-and-the-app-store)
 
 ## Adding an iOS app
 


### PR DESCRIPTION
While reading the docs I noticed that two of the links on the iOS getting started page were broken. Updated here so they link to their respective sections.