### PR TITLE
Custom Test Report script deeplink fix

### DIFF
--- a/_articles/en/testing/test-reports.md
+++ b/_articles/en/testing/test-reports.md
@@ -49,7 +49,7 @@ These Steps will run the tests defined in your repository and then store the out
 * [Device testing for iOS](/testing/device-testing-for-ios/)
 * [Running Xcode Tests](/testing/running-xcode-tests/) "%}
 
-{% include message_box.html type="important" title="Using custom Script Steps" content="You can use custom Script Steps to export test results to Test Reports. Read the details in our [Exporting from custom Script Steps to Test Reports]() guide."%} 
+{% include message_box.html type="important" title="Using custom Script Steps" content="You can use custom Script Steps to export test results to Test Reports. Read the details in our [Exporting from custom Script Steps to Test Reports](/testing/exporting-to-test-reports-from-custom-script-steps/) guide."%} 
 
 ## Configuring Test Reports
 


### PR DESCRIPTION
Fixed path to documentation page Exporting to Test Reports from custom Script Steps