### PR TITLE
Update getting-started-with-ios-apps.md

### DIFF
--- a/_articles/en/getting-started/getting-started-with-ios-apps.md
+++ b/_articles/en/getting-started/getting-started-with-ios-apps.md
@@ -53,7 +53,12 @@ If you have test targets defined, the **primary** workflow of an iOS app include
 
 The **Xcode Test for iOS** Step runs the pre-defined Xcode tests. It has a default configuration that does not need to be modified: if the tests are written correctly, they will work. You can find the same configuration options in Xcode, too.
 
-{% include message_box.html type="note" title="Check your Stack" content="If your simulator test fails with 'Ineligible destinations for the <your-app-scheme> scheme', then make sure the XCode version in the Stack tab is correct"%}
+{% include message_box.html type="note" title="Check your Stack" content="We recommend checking that the stack selected for your app has the same Xcode version you used to build the app.
+
+For example, if your simulator test fails with 'Ineligible destinations for the <your-app-scheme> scheme', then make sure the Xcode version in the Stack tab is correct.
+  
+You can read more about our stacks in the [Available stacks](/infrastructure/available-stacks/) guide.
+"%}
 
 The **Deploy to Bitrise.io** will deploy the following to the **Logs** and [**APPS & ARTIFACTS**](/builds/build-artifacts-online/) tab of the build:
 

--- a/_articles/en/getting-started/getting-started-with-ios-apps.md
+++ b/_articles/en/getting-started/getting-started-with-ios-apps.md
@@ -53,6 +53,8 @@ If you have test targets defined, the **primary** workflow of an iOS app include
 
 The **Xcode Test for iOS** Step runs the pre-defined Xcode tests. It has a default configuration that does not need to be modified: if the tests are written correctly, they will work. You can find the same configuration options in Xcode, too.
 
+{% include message_box.html type="note" title="Check your Stack" content="If your simulator test fails with 'Ineligible destinations for the <your-app-scheme> scheme', then make sure the XCode version in the Stack tab is correct"%}
+
 The **Deploy to Bitrise.io** will deploy the following to the **Logs** and [**APPS & ARTIFACTS**](/builds/build-artifacts-online/) tab of the build:
 
 * your Xcode test results


### PR DESCRIPTION
When I followed the Getting Started with iOS apps, I was stuck for more than a day trying to figure out why a recognized simulator was failing the test. It was quite a bad first-impression of Bitrise.
It would have been a lot more comfortable if the documentation had hinted that I should check the Stack tab for the XCode version.

When I made a new iOS project to test Bitrise, it defaulted to iOS 12.4, because I had upgraded to Xcode 10.3, but this Stack had apparently defaulted to 10.2, which did not support 12.4 and was therefore failing due to the missing simulator version.