### PR TITLE
fix: correct wrong information

### DIFF
--- a/_articles/en/code-signing/ios-code-signing/ionic-cordova-code-signing.md
+++ b/_articles/en/code-signing/ios-code-signing/ionic-cordova-code-signing.md
@@ -78,8 +78,7 @@ Bitrise supports both manual and automatic provisioning for Ionic and Cordova ap
    	inputs:
        - development_team: $BITRISE_DEVELOPER_TEAM 
        - package_type: development 
-       - code_sign_identity: $BITRISE_DEVELOPMENT_CODESIGN_IDENTITY 
-       - provisioning_profile: $BITRISE_DEVELOPMENT_PROFILE 
+       - code_sign_identity: iPhone Developer
        - configuration: debug
    ```
 
@@ -90,8 +89,7 @@ Bitrise supports both manual and automatic provisioning for Ionic and Cordova ap
        inputs:
        - development_team: $BITRISE_DEVELOPER_TEAM 
        - package_type: app-store 
-       - code_sign_identity: $BITRISE_PRODUCTION_CODESIGN_IDENTITY 
-       - provisioning_profile: $BITRISE_PRODUCTION_PROFILE 
+       - code_sign_identity: iPhone Developer
        - configuration: release
    ```
 5. Add the **Cordova Archive** or the **Ionic Archive** Step to your Workflow.


### PR DESCRIPTION
See https://cordova.apache.org/docs/en/latest/guide/platforms/ios/#signing-an-app

If the provisioning profile is set a manual provisioning is assumed, which makes the build fail.

The code signing identity should be "iPhone Developer" starting from Xcode 8. This version does not work on modern OS X anymore, which is why I just changed the config and did not leave a note.

Note: I did not touch the japanese version of these docs, since I don't know the language and am not sure if there is another hint in the text or anything.