### PR TITLE
Fixes broken links in getting-started-with-ios-apps.md

### DIFF
--- a/_articles/en/getting-started/getting-started-with-ios-apps.md
+++ b/_articles/en/getting-started/getting-started-with-ios-apps.md
@@ -81,8 +81,8 @@ You will need:
 1. Set the code signing type of your project in Xcode to either manual or automatic (Xcode managed), and generate an .ipa locally.
 2. Collect and upload the code signing files with [the codesigndoc tool](/code-signing/ios-code-signing/collecting-files-with-codesigndoc/).
 
-   The tool can also upload your code signing files to Bitrise - we recommend doing so! Otherwise, upload them manually: enter your [app's] (https://app.bitrise.io/dashboard/builds) Workflow Editor and select the **Code signing** tab, then upload the files in their respective fields.
-3. Go to your [app's] (https://app.bitrise.io/dashboard/builds), and select the **deploy** workflow in the **WORKFLOW** dropdown menu in the top left corner.
+   The tool can also upload your code signing files to Bitrise - we recommend doing so! Otherwise, upload them manually: enter your [app's](https://app.bitrise.io/dashboard/builds) Workflow Editor and select the **Code signing** tab, then upload the files in their respective fields.
+3. Go to your [app's](https://app.bitrise.io/dashboard/builds) Workflow Editor, and select the **deploy** workflow in the **WORKFLOW** dropdown menu in the top left corner.
 4. Check that you have the **Certificate and profile installer** Step in your workflow. It must be before the **Xcode Archive & Export for iOS** Step (you can have other Steps between the two, like **Xcode Test for iOS**).
 5. Check the **Select method for export** input of the **Xcode Archive & Export for iOS** Step. By default, it should be the `$BITRISE_EXPORT_METHOD` Environment Variable (Env Var). This Env Var stores the export method you selected when creating the app. If you selected **development** back then, you don't need to change the input. Otherwise, manually set it to **development**.
 
@@ -104,7 +104,7 @@ To deploy to Testflight and to the App Store, you will need more code signing fi
 
 1. On your local machine, set up App Store code signing for your project in Xcode, and export an App Store .ipa. If this fails locally, it will definitely fail on Bitrise, too!
 2. Collect and upload the code signing files with [the codesigndoc tool](/code-signing/ios-code-signing/collecting-files-with-codesigndoc/).
-3. Go to the [app's](https://app.bitrise.io/dashboard/builds) and create a [new workflow](/getting-started/getting-started-workflows/): click the **+ Workflow** button, enter the name of your new workflow and in the **BASED ON** dropdown menu, select **deploy**. This way the new workflow will be a copy of the basic **deploy** workflow.
+3. Go to the [app's](https://app.bitrise.io/dashboard/builds) Workflow Editor and create a [new workflow](/getting-started/getting-started-workflows/): click the **+ Workflow** button, enter the name of your new workflow and in the **BASED ON** dropdown menu, select **deploy**. This way the new workflow will be a copy of the basic **deploy** workflow.
 4. Set the **Select method for export** input of the **Xcode Archive & Export for iOS** Step to **app-store**.
 
    ![](/img/app-store-export-method-1.png)


### PR DESCRIPTION
I noticed a couple of links in `getting-started-with-ios-apps.md` were broken. This fixes it by removing the space between the brackets and parentheses in the markdown links. Also added 'Workflow Editor' which were seemingly missing from some sentences.