### PR TITLE
Update how to set your Git credentials to reference new Step

### DIFF
--- a/_articles/en/builds/setting-your-git-credentials-on-build-machines.md
+++ b/_articles/en/builds/setting-your-git-credentials-on-build-machines.md
@@ -19,11 +19,9 @@ The default Git username and user email address on our Stacks are the following:
 
 If you want to push back  (`git push`) any commits to your own repo from Bitrise **while running your build**, you have to **set your own username and the email address**. Here is how to do it!
 
-1. Add a **Script** Step as the very first step in your workflow. The Step has to come first before you'd `git commit`. This way you can make sure any changes you make to the current build will be attached to a commit associated with your username and email address.
-2. Add the following script to the **Script input** field and insert your own user name and email to the respective fields:
-
-       git config --global user.name "User Name"
-       git config --global user.email "email-for-the-commit@domain.com"
+1. Add a **Set Git Credentials** Step as the very first step in your workflow. The Step has to come first before you'd `git commit`. This way you can make sure any changes you make to the current build will be attached to a commit associated with your username and email address.
+2. In the **Git Username** field, set the value to your own user name.
+3. In the **Git Email Address** field, set the value to your own email address.
 3. [Start a build.](/builds/Starting-builds-manually/)
 
 If all went well, you should see the changes in your repository in your Git provider. The new username and email address will be visible for all future commits you push from your builds to Github.

--- a/_articles/en/builds/setting-your-git-credentials-on-build-machines.md
+++ b/_articles/en/builds/setting-your-git-credentials-on-build-machines.md
@@ -22,7 +22,7 @@ If you want to push back  (`git push`) any commits to your own repo from Bitrise
 1. Add a **Set Git Credentials** Step as the very first step in your workflow. The Step has to come first before you'd `git commit`. This way you can make sure any changes you make to the current build will be attached to a commit associated with your username and email address.
 2. In the **Git Username** field, set the value to your own user name.
 3. In the **Git Email Address** field, set the value to your own email address.
-3. [Start a build.](/builds/Starting-builds-manually/)
+4. [Start a build.](/builds/Starting-builds-manually/)
 
 If all went well, you should see the changes in your repository in your Git provider. The new username and email address will be visible for all future commits you push from your builds to Github.
 

--- a/_articles/en/builds/setting-your-git-credentials-on-build-machines.md
+++ b/_articles/en/builds/setting-your-git-credentials-on-build-machines.md
@@ -17,7 +17,12 @@ The default Git username and user email address on our Stacks are the following:
     git config --global user.email "please-set-your-email@bitrise.io"
     git config --global user.name "J. Doe (https://www.git-tower.com/learn/git/faq/change-author-name-email)"
 
-If you want to push back  (`git push`) any commits to your own repo from Bitrise **while running your build**, you have to **set your own username and the email address**. Here is how to do it!
+If you want to push back  (`git push`) any commits to your own repo from Bitrise **while running your build**, you have to **set your own username and the email address**. There are two ways to achieve this:
+
+- You can use a custom Script Step to set your credentials with the `git config` command.
+- You can use the **Set Git Credentials** Step. 
+
+Let's go through the latter option in detail:
 
 1. Add a **Set Git Credentials** Step as the very first step in your workflow. The Step has to come first before you'd `git commit`. This way you can make sure any changes you make to the current build will be attached to a commit associated with your username and email address.
 2. In the **Git Username** field, set the value to your own user name.


### PR DESCRIPTION
I figure this is the last piece of the puzzle in creating the step and submitting it to the public step repo - update the documentation to point to it.