### PR TITLE
Fix links to Ansible playbook used to generate VS/Xamarin stack

### DIFF
--- a/_articles/en/infrastructure/stack-update-and-removal-policy.md
+++ b/_articles/en/infrastructure/stack-update-and-removal-policy.md
@@ -44,7 +44,7 @@ The Android / Linux stacks are prepared with `docker`, using multiple separate 
 
 {% include message_box.html type="note" title="Deprecated Xamarin Studio Stacks" content=" Please note that Xamarin Studio stacks have been deprecated and replaced with the new Visual Studio for Mac stack. Make sure you switch to the Visual Studio for Mac one if you've been using the Xamarin Studio one before! "%}
 
-The Visual Studio for Mac stacks are built on top of the latest Stable Xcode stack, so the preinstalled building tools of the base Xcode stack are not updated and are the same as in the base Xcode stack. The Xamarin specific bits are applied on top of the base Xcode image **every week** when generating the Visual Studio for Mac stacks ([using this Ansible playbook](https://github.com/bitrise-io/osx-box-bootstrap/blob/master/xamarin-playbook.yml)).
+The Visual Studio for Mac stacks are built on top of the latest Stable Xcode stack, so the preinstalled building tools of the base Xcode stack are not updated and are the same as in the base Xcode stack. The Xamarin specific bits are applied on top of the base Xcode image **every week** when generating the Visual Studio for Mac stacks ([using this Ansible playbook](https://github.com/bitrise-io/osx-box-bootstrap/blob/master/roles/xamarin/tasks/main.yml)).
 
 The [dependency manager cache updates](/infrastructure/stack-update-and-removal-policy/#about-dependency-manager-cache-updates) are applied on these stacks too. Visual Studio for Mac stacks are upgraded to the latest Visual Studio for Mac versions on **every weekend**.
 

--- a/_articles/jp/infrastructure/stack-update-and-removal-policy.md
+++ b/_articles/jp/infrastructure/stack-update-and-removal-policy.md
@@ -35,7 +35,7 @@ The Android / Linux stacks are prepared with `docker`, using multiple separate 
 
 {% include message_box.html type="note" title="Deprecated Xamarin Studio Stacks" content=" Please note that Xamarin Studio stacks have been deprecated and replaced with the new Visual Studio for Mac stack. Make sure you switch to the Visual Studio for Mac one if you've been using the Xamarin Studio one before! "%}
 
-The Visual Studio for Mac stacks are built on top of the latest Stable Xcode stack, so the preinstalled building tools of the base Xcode stack are not updated and are the same as in the base Xcode stack. The Xamarin specific bits are applied on top of the base Xcode image **every week** when generating the Visual Studio for Mac stacks ([using this Ansible playbook](https://github.com/bitrise-io/osx-box-bootstrap/blob/master/xamarin-playbook.yml)).
+The Visual Studio for Mac stacks are built on top of the latest Stable Xcode stack, so the preinstalled building tools of the base Xcode stack are not updated and are the same as in the base Xcode stack. The Xamarin specific bits are applied on top of the base Xcode image **every week** when generating the Visual Studio for Mac stacks ([using this Ansible playbook](https://github.com/bitrise-io/osx-box-bootstrap/blob/master/roles/xamarin/tasks/main.yml)).
 
 The [dependency manager cache updates](/infrastructure/stack-update-and-removal-policy/#about-dependency-manager-cache-updates) are applied on these stacks too. Visual Studio for Mac stacks are upgraded to the latest Visual Studio for Mac versions on **every weekend**.
 


### PR DESCRIPTION
This file was moved in https://github.com/bitrise-io/osx-box-bootstrap/pull/161, but the URLs in the docs were not updated