### PR TITLE
fix ssh-keygen command

### DIFF
--- a/_articles/jp/faq/how-to-generate-ssh-keypair.md
+++ b/_articles/jp/faq/how-to-generate-ssh-keypair.md
@@ -10,7 +10,7 @@ menu:
 [Bitrise](https://www.bitrise.io)上で手動でSSHキーの設定を行う場合には、コマンドライン/ターミナルで以下のコマンドを実行することでSSHキーペアを生成できます。
 
 ```
-ssh-keygen -t rsa -b 4096 -P '' -f ./bitrise-ssh
+ssh-keygen -t rsa -b 4096 -P '' -f ./bitrise-ssh -m PEM
 ```
 
 これにより、カレントディレクトリ(コマンドを実行したディレクトリ)内に以下の２つのファイルが生成されます。


### PR DESCRIPTION
`-m PEM` is required on the Mojave OS or later.
port of https://github.com/bitrise-io/devcenter/commit/a96c15eacde79d5d50048e6302813ae11ab46951

related posts:

- https://serverfault.com/questions/939909/ssh-keygen-does-not-create-rsa-private-key
- https://qiita.com/Jung0/items/13cd9f6313b7137ac8c6 (in Japanese)