### PR TITLE
fix broken style on ssh-keypair in ja-JP

### DIFF
--- a/_articles/jp/faq/how-to-generate-ssh-keypair.md
+++ b/_articles/jp/faq/how-to-generate-ssh-keypair.md
@@ -15,9 +15,9 @@ ssh-keygen -t rsa -b 4096 -P '' -f ./bitrise-ssh
 
 これにより、カレントディレクトリ(コマンドを実行したディレクトリ)内に以下の２つのファイルが生成されます。
 
-- `bitrise-ssh` (秘密鍵)
-- `bitrise-ssh.pub` (公開鍵)
+* `bitrise-ssh` (秘密鍵)
+* `bitrise-ssh.pub` (公開鍵)
 
 
-生成された__公開鍵__をGitホスティングサービス(GitHubやBitbucketなど)にコピー＆ペーストしてください。
-また、[Bitrise](https://www.bitrise.io)にアプリを登録する際には、__秘密鍵__を提供する必要があります。
+生成された **公開鍵** をGitホスティングサービス(GitHubやBitbucketなど)にコピー＆ペーストしてください。
+また、[Bitrise](https://www.bitrise.io)にアプリを登録する際には、 **秘密鍵** を提供する必要があります。


### PR DESCRIPTION
Currently, keywords 公開鍵 (public key), and 秘密鍵 (private key) are enclosed in underscores in Japanese.

https://devcenter.bitrise.io/jp/faq/how-to-generate-ssh-keypair/

![image](https://user-images.githubusercontent.com/1157344/95530007-99746600-0a17-11eb-8b5d-641a24e691a3.png)

In English, their corresponding keywords are rendered in **bold**.

https://devcenter.bitrise.io/faq/how-to-generate-ssh-keypair/

![image](https://user-images.githubusercontent.com/1157344/95530014-a002dd80-0a17-11eb-9d0f-5209cae38e9d.png)

So, they should be **公開鍵**, **秘密鍵** instead of \_\_公開鍵\_\_, \_\_秘密鍵\_\_ in Japanese.