### PR TITLE
Add an explanation for $BITRISE_GIT_MESSAGE to DeployGate's doc.

### DIFF
--- a/_articles/en/deploy/deploy-apps-to-deploygate-from-bitrise.md
+++ b/_articles/en/deploy/deploy-apps-to-deploygate-from-bitrise.md
@@ -43,7 +43,7 @@ You can also set optional variables for using advanced features as below:
 
 | Input Variables | Description |
 | --- | --- |
-| Short Message | Summary of update shown on DeployGate.<br>You can use $GIT_CLONE_COMMIT_MESSAGE_SUBJECT if you want to use the same message as git commit |
+| Short Message | Summary of update shown on DeployGate.<br>You can use $BITRISE_GIT_MESSAGE if you want to use the commit message, the pull request title, or the message you specified when you triggered the build manually. |
 | Distribution Key | You can make multiple public install links (we called it Distribution Page) for a different version of app binary in the same app. <br>By specifying the distribution page's hash, that distribution page will be updated simultaneously. The "xxxx" portion of the distributed page's URL like https://deploygate.com/distributions/xxxx |
 | Distribution Name | Specify the name of the updated distribution page. If nothing exists, a new distribution page will be created. Possible usage includes creating distribution pages for each Git branch name. (for example $BITRISE_GIT_BRANCH) |
 | Release Note | Message for the new release in distribution page. This message will be notified to your distribution page's testers |

--- a/_articles/jp/deploy/deploy-apps-to-deploygate-from-bitrise.md
+++ b/_articles/jp/deploy/deploy-apps-to-deploygate-from-bitrise.md
@@ -45,7 +45,7 @@ DeployGate にアプリをアップロードするには、Bitrise のワーク�
 
 | 入力変数 | 説明 |
 |-|-|
-|Short Message|DeployGate で表示するアップデートの概要。<br>git commit と同じメッセージを使いたい場合は `$GIT_CLONE_COMMIT_MESSAGE_SUBJECT` を使います。|
+|Short Message|DeployGate で表示するアップデートの概要。<br>コミットメッセージ、プルリクエストタイトル、または手動でビルドを起動した場合に指定したメッセージを使いたい場合は `$BITRISE_GIT_MESSAGE` を使います。|
 |Distribution Key|同一アプリのさまざまなバージョン用のパブリックインストールページを複数作成できます（**`配布ページ`** と呼びます）。<br>配布ページのハッシュを指定することにより、アップロードと同時に配布ページが更新されます。https://deploygate.com/distributions/xxxx のように配布されたページの "xxxx" 部分です。|
 |Distribution Name|更新する配布ページの名前を指定します。もし存在しなければ、新しい配布ページが作成されます。Git ブランチ名ごとに配布ページを作成することもできます。（例: `$BITRISE_GIT_BRANCH`）|
 |Release Note|配布ページの新しいリリース用のメッセージ。このメッセージは配布ページのテスターに通知されます。|


### PR DESCRIPTION
I think `$BITRISE_GIT_MESSAGE` is more convenient than `$GIT_CLONE_COMMIT_MESSAGE_SUBJECT` for users. So I want to fix the document.

Thank you.