### PR TITLE
Fix a notation for iOS

### DIFF
--- a/_articles/jp/getting-started/getting-started-with-flutter-apps.md
+++ b/_articles/jp/getting-started/getting-started-with-flutter-apps.md
@@ -14,7 +14,7 @@ menu:
 ---
 このガイドではBitriseでのFlutterアプリのセットアップからテスト、ビルド、デプロイまでの説明します。
 
-FlutterとはAndroidやiOs端末向けアプリケーション開発ツール、モバイルSDKです。BitriseはFlutterアプリをサポートしています:　全てのFlutter needsに応えるべくBitriseには専用のステップがあります。
+FlutterとはAndroidやiOS端末向けアプリケーション開発ツール、モバイルSDKです。BitriseはFlutterアプリをサポートしています:　全てのFlutter needsに応えるべくBitriseには専用のステップがあります。
 
 ## Flutterアプリを追加
 


### PR DESCRIPTION
In other writings, it was labeled as iOS, so I unified it. 

I recommend that this project set up text lint to avoid this kind of PR. 
I helped [OWASP/CheatSheetSeries](https://github.com/OWASP/CheatSheetSeries) to prevent this kind of issue so I think I would help.

ref:
- https://github.com/OWASP/CheatSheetSeries/pull/428