### PR TITLE
Added `Expose for Pull Requests` step

### DIFF
--- a/_articles/en/testing/measuring-your-code-coverage-with-codecov.md
+++ b/_articles/en/testing/measuring-your-code-coverage-with-codecov.md
@@ -35,7 +35,7 @@ In order to start using Codecov, you must be generating coverage reports with yo
 
    ![](/img/pic1.jpg)
 3. Add the **Codecov** Step to your Workflow on Bitrise. Make sure you add the Step after the Steps that test and collect coverage.![](/img/pic2.jpg)
-4. Add the Codecov upload token as a secret variable, `CODECOV_TOKEN`, and click **Add new**.![](/img/pic3.jpg)
+4. Add the Codecov upload token as a secret variable, `CODECOV_TOKEN`, and set `Expose for Pull Requests` to true. Click **Add new**.![](/img/pic3.jpg)
 5. Click **Save** and start a new build to get coverage metrics.
 
 {% include message_box.html type="info" title="Additional options" content="The **Codecov** Step wraps around the Codecov [bash uploader](https://docs.codecov.io/docs/about-the-codecov-bash-uploader). You can add additional options in the Step listed in our [arguments documentation](https://docs.codecov.io/docs/about-the-codecov-bash-uploader#arguments)."%}


### PR DESCRIPTION
Based on this discussion https://discuss.bitrise.io/t/codecov-400-error-t-repository-token/9850 the `Expose for Pull Requests` value of the secret should to `true`