### PR TITLE
Fix JDK11 install code snippet for Big Sur stacks

### DIFF
--- a/_articles/en/infrastructure/virtual-machines.md
+++ b/_articles/en/infrastructure/virtual-machines.md
@@ -159,7 +159,7 @@ You can do all of it in one **Script** Step though, so it’s quite simple. To s
 2. Add the following commands to the **Script content** input of the Step:
 
    ``` 
-   jenv global system
+   jenv global 11
    export JAVA_HOME=\"$(jenv prefix)\"
    envman add --key JAVA_HOME --value \"$(jenv prefix)\"
    ```


### PR DESCRIPTION
Using `jenv global system` on our Xcode 12.5 (Big Sur) stack produces an incorrect Java setup. `jenv prefix` simply returns `/usr`. Setting an installed Java version explicitly by `jenv global 11` solves the issue, `jenv prefix` returns `/Users/vagrant/.jenv/versions/11`.

Tested the change on both older stacks (Catalina based) and the latest Big Sur stack.